### PR TITLE
Resolve variable scoping issues.

### DIFF
--- a/sample_tpl/scope-2.tpl
+++ b/sample_tpl/scope-2.tpl
@@ -1,0 +1,17 @@
+fun main() -> int {
+  var a = 1
+  var b = 2
+  {
+    var a = 3
+    b = b + a               // b = 2 + 3 = 5
+  }
+  {
+    var b = 721
+  }
+
+  b = b + a                 // b = 5 + 1 = 6
+  var a = 7
+  b = b * a                 // b = 6 * 7 = 42
+
+  return b
+}

--- a/sample_tpl/scope-2.tpl
+++ b/sample_tpl/scope-2.tpl
@@ -8,10 +8,20 @@ fun main() -> int {
   {
     var b = 721
   }
-
-  b = b + a                 // b = 5 + 1 = 6
-  var a = 7
-  b = b * a                 // b = 6 * 7 = 42
+  {
+    b = b + a               // b = 5 + 1 = 6
+    var a = 5
+    b = b * a               // b = 6 * 5 = 30
+  }
+  b = b * a                 // b = 30 * 1 = 30
+  {
+    var c = 12
+    {
+      {
+        b = b + c
+      }
+    }
+  }
 
   return b
 }

--- a/sample_tpl/scope.tpl
+++ b/sample_tpl/scope.tpl
@@ -12,5 +12,5 @@ fun main() -> int {
       }
     }
   }
-  return 3                  // return 2
+  return 3                  // return 3
 }

--- a/sample_tpl/tpl_tests.txt
+++ b/sample_tpl/tpl_tests.txt
@@ -19,6 +19,7 @@ scan-table.tpl,500
 scan-table-2.tpl,1999950
 scan-table-3.tpl,2000000
 scope.tpl,3
+scope-2.tpl,42
 short-circuit.tpl,1
 simple.tpl,44
 single-line-comment.tpl,46

--- a/src/include/parsing/parser.h
+++ b/src/include/parsing/parser.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "llvm/ADT/DenseMap.h"
 
 #include <string>
 #include <unordered_set>
+
+#include "llvm/ADT/DenseMap.h"
 
 #include "ast/ast.h"
 #include "ast/ast_node_factory.h"

--- a/src/include/parsing/parser.h
+++ b/src/include/parsing/parser.h
@@ -83,35 +83,35 @@ class Parser {
   // Parsing productions
   // -------------------------------------------------------
 
-  ast::Decl *ParseDecl(parsing::ParsingContext *pctx);
+  ast::Decl *ParseDecl(ParsingContext *pctx);
 
-  ast::Decl *ParseFunctionDecl(parsing::ParsingContext *pctx);
+  ast::Decl *ParseFunctionDecl(ParsingContext *pctx);
 
-  ast::Decl *ParseStructDecl(parsing::ParsingContext *pctx);
+  ast::Decl *ParseStructDecl(ParsingContext *pctx);
 
-  ast::Decl *ParseVariableDecl(parsing::ParsingContext *pctx);
+  ast::Decl *ParseVariableDecl(ParsingContext *pctx);
 
-  ast::Stmt *ParseStmt(parsing::ParsingContext *pctx);
+  ast::Stmt *ParseStmt(ParsingContext *pctx);
 
-  ast::Stmt *ParseSimpleStmt(parsing::ParsingContext *pctx);
+  ast::Stmt *ParseSimpleStmt(ParsingContext *pctx);
 
-  ast::Stmt *ParseBlockStmt(parsing::ParsingContext *pctx);
+  ast::Stmt *ParseBlockStmt(ParsingContext *pctx);
 
   class ForHeader;
 
-  ForHeader ParseForHeader(parsing::ParsingContext *pctx);
+  ForHeader ParseForHeader(ParsingContext *pctx);
 
-  ast::Stmt *ParseForStmt(parsing::ParsingContext *pctx);
+  ast::Stmt *ParseForStmt(ParsingContext *pctx);
 
-  ast::Stmt *ParseIfStmt(parsing::ParsingContext *pctx);
+  ast::Stmt *ParseIfStmt(ParsingContext *pctx);
 
-  ast::Stmt *ParseReturnStmt(parsing::ParsingContext *pctx);
+  ast::Stmt *ParseReturnStmt(ParsingContext *pctx);
 
-  ast::Expr *ParseExpr(parsing::ParsingContext *pctx);
+  ast::Expr *ParseExpr(ParsingContext *pctx);
 
-  ast::Expr *ParseBinaryOpExpr(parsing::ParsingContext *pctx, u32 min_prec);
+  ast::Expr *ParseBinaryOpExpr(ParsingContext *pctx, u32 min_prec);
 
-  ast::Expr *ParseUnaryOpExpr(parsing::ParsingContext *pctx);
+  ast::Expr *ParseUnaryOpExpr(ParsingContext *pctx);
 
   ast::Expr *ParsePrimaryExpr(ParsingContext *pctx);
 
@@ -119,19 +119,19 @@ class Parser {
 
   ast::Expr *ParseFunctionLitExpr(ParsingContext *pctx);
 
-  ast::Expr *ParseType(parsing::ParsingContext *pctx);
+  ast::Expr *ParseType(ParsingContext *pctx);
 
-  ast::Expr *ParseFunctionType(parsing::ParsingContext *pctx);
+  ast::Expr *ParseFunctionType(ParsingContext *pctx);
 
-  ast::Expr *ParsePointerType(parsing::ParsingContext *pctx);
+  ast::Expr *ParsePointerType(ParsingContext *pctx);
 
-  ast::Expr *ParseArrayType(parsing::ParsingContext *pctx);
+  ast::Expr *ParseArrayType(ParsingContext *pctx);
 
-  ast::Expr *ParseStructType(parsing::ParsingContext *pctx);
+  ast::Expr *ParseStructType(ParsingContext *pctx);
 
-  ast::Expr *ParseMapType(parsing::ParsingContext *pctx);
+  ast::Expr *ParseMapType(ParsingContext *pctx);
 
-  ast::Attributes *ParseAttributes(parsing::ParsingContext *pctx);
+  ast::Attributes *ParseAttributes(ParsingContext *pctx);
 
  private:
   // The source code scanner

--- a/src/include/parsing/parser.h
+++ b/src/include/parsing/parser.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <string>
 #include <unordered_set>
 

--- a/src/include/parsing/parser.h
+++ b/src/include/parsing/parser.h
@@ -92,20 +92,6 @@ class Parser {
     return context()->GetIdentifier(literal);
   }
 
-  // Get the current symbol's name within the parsing context scope
-  ast::Identifier GetScopedSymbol(parsing::ParsingContext *pctx) {
-    const std::string &literal = scanner()->current_literal();
-    std::string sym_name = pctx->GetScopedSymbolName(literal);
-    return context()->GetIdentifier(sym_name);
-  }
-
-  // Get the current symbol, making it unique within this parsing context
-  ast::Identifier GetUniqueSymbol(parsing::ParsingContext *pctx) {
-    const std::string &literal = scanner()->current_literal();
-    const std::string &sym_name = pctx->MakeUniqueSymbolName(literal);
-    return context()->GetIdentifier(sym_name);
-  }
-
   // In case of errors, sync up to any token in the list
   void Sync(const std::unordered_set<Token::Type> &s);
 

--- a/src/include/parsing/parser.h
+++ b/src/include/parsing/parser.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "LLVM/ADT/DenseMap.h"
+#include "llvm/ADT/DenseMap.h"
 
 #include <string>
 #include <unordered_set>

--- a/src/include/parsing/parser.h
+++ b/src/include/parsing/parser.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "LLVM/ADT/DenseMap.h"
+
 #include <string>
 #include <unordered_set>
 
@@ -7,6 +9,7 @@
 #include "ast/ast_node_factory.h"
 #include "ast/context.h"
 #include "ast/identifier.h"
+#include "parsing/parsing_context.h"
 #include "parsing/scanner.h"
 #include "sema/error_reporter.h"
 
@@ -89,6 +92,20 @@ class Parser {
     return context()->GetIdentifier(literal);
   }
 
+  // Get the current symbol's name within the parsing context scope
+  ast::Identifier GetScopedSymbol(parsing::ParsingContext *pctx) {
+    const std::string &literal = scanner()->current_literal();
+    std::string sym_name = pctx->GetScopedSymbolName(literal);
+    return context()->GetIdentifier(sym_name);
+  }
+
+  // Get the current symbol, making it unique within this parsing context
+  ast::Identifier GetUniqueSymbol(parsing::ParsingContext *pctx) {
+    const std::string &literal = scanner()->current_literal();
+    const std::string &sym_name = pctx->MakeUniqueSymbolName(literal);
+    return context()->GetIdentifier(sym_name);
+  }
+
   // In case of errors, sync up to any token in the list
   void Sync(const std::unordered_set<Token::Type> &s);
 
@@ -96,55 +113,55 @@ class Parser {
   // Parsing productions
   // -------------------------------------------------------
 
-  ast::Decl *ParseDecl();
+  ast::Decl *ParseDecl(parsing::ParsingContext *pctx);
 
-  ast::Decl *ParseFunctionDecl();
+  ast::Decl *ParseFunctionDecl(parsing::ParsingContext *pctx);
 
-  ast::Decl *ParseStructDecl();
+  ast::Decl *ParseStructDecl(parsing::ParsingContext *pctx);
 
-  ast::Decl *ParseVariableDecl();
+  ast::Decl *ParseVariableDecl(parsing::ParsingContext *pctx);
 
-  ast::Stmt *ParseStmt();
+  ast::Stmt *ParseStmt(parsing::ParsingContext *pctx);
 
-  ast::Stmt *ParseSimpleStmt();
+  ast::Stmt *ParseSimpleStmt(parsing::ParsingContext *pctx);
 
-  ast::Stmt *ParseBlockStmt();
+  ast::Stmt *ParseBlockStmt(parsing::ParsingContext *pctx);
 
   class ForHeader;
 
-  ForHeader ParseForHeader();
+  ForHeader ParseForHeader(parsing::ParsingContext *pctx);
 
-  ast::Stmt *ParseForStmt();
+  ast::Stmt *ParseForStmt(parsing::ParsingContext *pctx);
 
-  ast::Stmt *ParseIfStmt();
+  ast::Stmt *ParseIfStmt(parsing::ParsingContext *pctx);
 
-  ast::Stmt *ParseReturnStmt();
+  ast::Stmt *ParseReturnStmt(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseExpr();
+  ast::Expr *ParseExpr(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseBinaryOpExpr(u32 min_prec);
+  ast::Expr *ParseBinaryOpExpr(parsing::ParsingContext *pctx, u32 min_prec);
 
-  ast::Expr *ParseUnaryOpExpr();
+  ast::Expr *ParseUnaryOpExpr(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseLeftHandSideExpression();
+  ast::Expr *ParseLeftHandSideExpression(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParsePrimaryExpr();
+  ast::Expr *ParsePrimaryExpr(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseFunctionLitExpr();
+  ast::Expr *ParseFunctionLitExpr(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseType();
+  ast::Expr *ParseType(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseFunctionType();
+  ast::Expr *ParseFunctionType(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParsePointerType();
+  ast::Expr *ParsePointerType(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseArrayType();
+  ast::Expr *ParseArrayType(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseStructType();
+  ast::Expr *ParseStructType(parsing::ParsingContext *pctx);
 
-  ast::Expr *ParseMapType();
+  ast::Expr *ParseMapType(parsing::ParsingContext *pctx);
 
-  ast::Attributes *ParseAttributes();
+  ast::Attributes *ParseAttributes(parsing::ParsingContext *pctx);
 
  private:
   // The source code scanner

--- a/src/include/parsing/parsing_context.h
+++ b/src/include/parsing/parsing_context.h
@@ -73,22 +73,18 @@ class ParsingContext {
     }
 
     // Otherwise, a new unique symbol must be created.
-    // TODO(WAN): the string appends probably suck for performance.
 
-    // We append the number of known symbols to our identifier since that
-    // guarantees no conflict between our own generated variables.
+    // We prepend the number of known symbols to our identifier since that
+    // guarantees no conflict between our own generated variables and also
+    // between user-defined variables which cannot start with numbers.
     const std::string num_symbols_str =
-        "_tpl" + std::to_string(root_known_symbols_->size());
+        std::to_string(root_known_symbols_->size());
 
-    std::string new_sym_name(sym.data());
-    new_sym_name.append(num_symbols_str);
+    // sym.data() is technically unnecessary, but may be useful for debugging.
+    std::string new_sym_name(num_symbols_str);
+    new_sym_name.append(sym.data());
 
     auto new_sym = ctx->GetIdentifier(new_sym_name);
-    while (SymbolExists(new_sym)) {
-      new_sym_name.append(num_symbols_str);
-      new_sym = ctx->GetIdentifier(new_sym_name);
-    }
-
     symbols_.erase(sym);
     symbols_.insert({sym, new_sym});
     root_known_symbols_->insert(new_sym);

--- a/src/include/parsing/parsing_context.h
+++ b/src/include/parsing/parsing_context.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <string>
 #include <unordered_map>
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 
@@ -115,3 +117,4 @@ class ParsingContext {
 };
 
 }  // namespace tpl::parsing
+

--- a/src/include/parsing/parsing_context.h
+++ b/src/include/parsing/parsing_context.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <unordered_map>
+#include "llvm/ADT/DenseMap.h"
+
+#include "ast/context.h"
+#include "ast/identifier.h"
+#include "util/common.h"
+
+namespace tpl::parsing {
+
+class ParsingContext {
+ public:
+  ParsingContext() : outer_(nullptr), scope_level_(0) {}
+
+  ParsingContext NewNestedContext() {
+    return ParsingContext(this, scope_level_ + 1);
+  }
+
+  bool SymbolNameExists(const std::string &sym_name) {
+    for (const ParsingContext *ctx = this; ctx != nullptr; ctx = ctx->outer_) {
+      auto iter = ctx->symbols_.find(sym_name);
+      if (iter != ctx->symbols_.end()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const std::string &GetScopedSymbolName(const std::string &sym_name) {
+    for (const ParsingContext *ctx = this; ctx != nullptr; ctx = ctx->outer_) {
+      auto iter = ctx->symbols_.find(sym_name);
+      if (iter != ctx->symbols_.end()) {
+        return iter->second;
+      }
+    }
+    TPL_ASSERT(false, "No name?");
+    return sym_name;
+  }
+
+  const std::string &MakeUniqueSymbolName(const std::string &sym_name) {
+    // if the symbol doesn't exist, we're good. map the symbol to itself.
+    if (!SymbolNameExists(sym_name)) {
+      symbols_[sym_name] = sym_name;
+      return sym_name;
+    }
+    // otherwise, we must make a new symbol.
+    // TODO(WAN): more efficient way?
+    auto new_sym_name = new std::string(sym_name);
+    new_sym_name->append(std::to_string(scope_level_));
+    symbols_[sym_name] = *new_sym_name;
+    return *new_sym_name;
+  }
+
+ private:
+  ParsingContext(ParsingContext *outer, u8 scope_level)
+      : outer_(outer), scope_level_(scope_level) {}
+
+  llvm::StringMap<std::string> symbols_;
+  ParsingContext *outer_;
+  u8 scope_level_;
+};
+
+}  // namespace tpl::parsing

--- a/src/include/parsing/parsing_context.h
+++ b/src/include/parsing/parsing_context.h
@@ -115,6 +115,5 @@ class ParsingContext {
   /* Outer scope. */
   ParsingContext *outer_;
 };
-
 }  // namespace tpl::parsing
 

--- a/src/include/parsing/parsing_context.h
+++ b/src/include/parsing/parsing_context.h
@@ -116,4 +116,3 @@ class ParsingContext {
   ParsingContext *outer_;
 };
 }  // namespace tpl::parsing
-

--- a/src/include/parsing/parsing_context.h
+++ b/src/include/parsing/parsing_context.h
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 
 #include "ast/context.h"
 #include "ast/identifier.h"
@@ -9,24 +10,38 @@
 
 namespace tpl::parsing {
 
+/**
+ * ParsingContext manages symbols across the entire parse tree.
+ */
 class ParsingContext {
  public:
-  ParsingContext() : outer_(nullptr), scope_level_(0) {}
+  /**
+   * Creates a new empty parsing context with no parent.
+   */
+  ParsingContext() : root_known_symbols_(&known_symbols_), outer_(nullptr) {}
 
+  /**
+   * @return a new child of the current context
+   */
   ParsingContext NewNestedContext() {
-    return ParsingContext(this, scope_level_ + 1);
+    return ParsingContext(root_known_symbols_, this);
   }
 
+  /**
+   * Check if the symbol exists ANYWHERE in the root ParsingContext tree.
+   * @param sym symbol that we're looking for
+   * @return true if the symbol exists
+   */
   bool SymbolExists(ast::Identifier sym) {
-    for (const ParsingContext *ctx = this; ctx != nullptr; ctx = ctx->outer_) {
-      auto iter = ctx->symbols_.find(sym);
-      if (iter != ctx->symbols_.end()) {
-        return true;
-      }
-    }
-    return false;
+    auto iter = root_known_symbols_->find(sym);
+    return iter != root_known_symbols_->end();
   }
 
+  /**
+   * Returns the scoped version of the given identifier.
+   * @param sym original version of the identifier
+   * @return scoped version of the given identifier
+   */
   ast::Identifier GetScopedSymbol(ast::Identifier sym) {
     for (const ParsingContext *ctx = this; ctx != nullptr; ctx = ctx->outer_) {
       auto iter = ctx->symbols_.find(sym);
@@ -39,27 +54,64 @@ class ParsingContext {
   }
 
   ast::Identifier MakeUniqueSymbol(ast::Context *ctx, ast::Identifier sym) {
-    // if the symbol doesn't exist, we're good. map the symbol to itself.
+    // TPL does not allow re-declaring variables in the same scope.
+    // We can support this easily by removing the below check.
+
+    // If the symbol is already within this scope, we just return it.
+    auto iter = symbols_.find(sym);
+    if (iter != symbols_.end()) {
+      return iter->second;
+    }
+
+    // If the symbol doesn't exist anywhere, declare it here.
     if (!SymbolExists(sym)) {
       symbols_.insert({sym, sym});
+      root_known_symbols_->insert(sym);
       return sym;
     }
-    // otherwise, we must make a new symbol.
-    auto new_sym_name = new std::string(sym.data());
-    new_sym_name->append(std::to_string(scope_level_));
-    auto new_sym = ctx->GetIdentifier(*new_sym_name);
+
+    // Otherwise, a new unique symbol must be created.
+    // TODO(WAN): the string appends probably suck for performance.
+
+    // We append the number of known symbols to our identifier since that
+    // guarantees no conflict between our own generated variables.
+    const std::string num_symbols_str =
+        "_tpl" + std::to_string(root_known_symbols_->size());
+
+    std::string new_sym_name(sym.data());
+    new_sym_name.append(num_symbols_str);
+
+    auto new_sym = ctx->GetIdentifier(new_sym_name);
+    while (SymbolExists(new_sym)) {
+      new_sym_name.append(num_symbols_str);
+      new_sym = ctx->GetIdentifier(new_sym_name);
+    }
+
     symbols_.erase(sym);
     symbols_.insert({sym, new_sym});
+    root_known_symbols_->insert(new_sym);
     return new_sym;
   }
 
  private:
-  ParsingContext(ParsingContext *outer, u8 scope_level)
-      : outer_(outer), scope_level_(scope_level) {}
+  /**
+   * Creates a new ParsingContext with the given outer scope and scope level.
+   * @param outer Outer context that encapsulates this parsing context
+   * @param scope_level The scope level of the current parsing context
+   */
+  ParsingContext(llvm::DenseSet<ast::Identifier> *root_known_symbols,
+                 ParsingContext *outer)
+      : root_known_symbols_(root_known_symbols), outer_(outer) {}
 
+  /* In the root parsing context. */
+  llvm::DenseSet<ast::Identifier> known_symbols_;
+  /* In all children's parsing context. */
+  llvm::DenseSet<ast::Identifier> *root_known_symbols_;
+
+  /* Symbols in this scope. */
   llvm::DenseMap<ast::Identifier, ast::Identifier> symbols_;
+  /* Outer scope. */
   ParsingContext *outer_;
-  u8 scope_level_;
 };
 
 }  // namespace tpl::parsing

--- a/src/include/vm/bytecodes.h
+++ b/src/include/vm/bytecodes.h
@@ -191,7 +191,7 @@ namespace tpl::vm {
   F(Cos, OperandType::Local, OperandType::Local)                                                                       \
   F(Cot, OperandType::Local, OperandType::Local)                                                                       \
   F(Sin, OperandType::Local, OperandType::Local)                                                                       \
-  F(Tan, OperandType::Local, OperandType::Local)                                                                       \
+  F(Tan, OperandType::Local, OperandType::Local)
 
 // clang-format on
 

--- a/src/parsing/parser.cpp
+++ b/src/parsing/parser.cpp
@@ -112,7 +112,7 @@ ast::Decl *Parser::ParseVariableDecl(parsing::ParsingContext *pctx) {
 
   // The name
   Expect(Token::Type::IDENTIFIER);
-  ast::Identifier name = GetUniqueSymbol(pctx);
+  ast::Identifier name = pctx->MakeUniqueSymbol(context(), GetSymbol());
 
   // The type (if exists)
   ast::Expr *type = nullptr;
@@ -526,7 +526,8 @@ ast::Expr *Parser::ParsePrimaryExpr(parsing::ParsingContext *pctx) {
     case Token::Type::IDENTIFIER: {
       Next();
       const SourcePosition &position = scanner()->current_position();
-      return node_factory()->NewIdentifierExpr(position, GetScopedSymbol(pctx));
+      return node_factory()->NewIdentifierExpr(
+          position, pctx->GetScopedSymbol(GetSymbol()));
     }
     case Token::Type::INTEGER: {
       Next();

--- a/src/parsing/parser.cpp
+++ b/src/parsing/parser.cpp
@@ -51,9 +51,7 @@ ast::Decl *Parser::ParseDecl(parsing::ParsingContext *pctx) {
     case Token::Type::FUN: {
       return ParseFunctionDecl(pctx);
     }
-    default: {
-      break;
-    }
+    default: { break; }
   }
 
   // Report error, sync up and try again
@@ -163,9 +161,7 @@ ast::Stmt *Parser::ParseStmt(parsing::ParsingContext *pctx) {
       ast::Decl *var_decl = ParseVariableDecl(pctx);
       return node_factory()->NewDeclStmt(var_decl);
     }
-    default: {
-      return ParseSimpleStmt(pctx);
-    }
+    default: { return ParseSimpleStmt(pctx); }
   }
 }
 
@@ -564,9 +560,7 @@ ast::Expr *Parser::ParsePrimaryExpr(parsing::ParsingContext *pctx) {
       Expect(Token::Type::RIGHT_PAREN);
       return expr;
     }
-    default: {
-      break;
-    }
+    default: { break; }
   }
 
   // Error
@@ -614,9 +608,7 @@ ast::Expr *Parser::ParseType(parsing::ParsingContext *pctx) {
     case Token::Type::STRUCT: {
       return ParseStructType(pctx);
     }
-    default: {
-      break;
-    }
+    default: { break; }
   }
 
   // Error

--- a/src/parsing/parser.cpp
+++ b/src/parsing/parser.cpp
@@ -51,9 +51,7 @@ ast::Decl *Parser::ParseDecl(ParsingContext *pctx) {
     case Token::Type::FUN: {
       return ParseFunctionDecl(pctx);
     }
-    default: {
-      break;
-    }
+    default: { break; }
   }
 
   // Report error, sync up and try again
@@ -162,9 +160,7 @@ ast::Stmt *Parser::ParseStmt(ParsingContext *pctx) {
       ast::Decl *var_decl = ParseVariableDecl(pctx);
       return node_factory_->NewDeclStmt(var_decl);
     }
-    default: {
-      return ParseSimpleStmt(pctx);
-    }
+    default: { return ParseSimpleStmt(pctx); }
   }
 }
 
@@ -433,9 +429,7 @@ ast::Expr *Parser::ParseUnaryOpExpr(ParsingContext *pctx) {
       ast::Expr *expr = ParseUnaryOpExpr(pctx);
       return node_factory_->NewUnaryOpExpr(position, op, expr);
     }
-    default: {
-      break;
-    }
+    default: { break; }
   }
 
   return ParsePrimaryExpr(pctx);
@@ -483,9 +477,7 @@ ast::Expr *Parser::ParsePrimaryExpr(ParsingContext *pctx) {
         result = node_factory_->NewIndexExpr(result->position(), result, index);
         break;
       }
-      default: {
-        break;
-      }
+      default: { break; }
     }
   } while (Token::IsCallOrMemberOrIndex(peek()));
 
@@ -543,9 +535,7 @@ ast::Expr *Parser::ParseOperand(ParsingContext *pctx) {
       Expect(Token::Type::RIGHT_PAREN);
       return expr;
     }
-    default: {
-      break;
-    }
+    default: { break; }
   }
 
   // Error
@@ -593,9 +583,7 @@ ast::Expr *Parser::ParseType(ParsingContext *pctx) {
     case Token::Type::STRUCT: {
       return ParseStructType(pctx);
     }
-    default: {
-      break;
-    }
+    default: { break; }
   }
 
   // Error


### PR DESCRIPTION
Fix #7 by making names unique as we parse. This requires threading a parsing context through the various parser.h methods. Due to how bytecode_function_info resolves variables, names are made globally unique across a parse tree.

Instructions:
```
I think you can move all those parameters [ParsingContext] into a scope object as a member variable
Similar to how `Scope` is done in `Sema`
```